### PR TITLE
Remove Bill and Wesley from PGB

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -49,8 +49,6 @@ Current PGB members:
 
 - Jim Amsden (co-chair, IBM)
 - Andrew Berezovskyi (co-chair, KTH Royal Institute of Technology)
-- Bill Chown (Siemens)
-- Wesley Coelho (Tasktop Technologies)
 - Axel Reichwein (Koneksys)
 
 ## Technical Steering Committee (TSC)


### PR DESCRIPTION
Opening this pull request to update the PGB. Tasktop Technologies dropped OASIS membership last year so ceased to qualify as a project sponsor. Bill Chown apparently no longer is with Siemens so cannot be their representative.